### PR TITLE
Aw merchantitems 34

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,10 +1,13 @@
 class ItemsController < ApplicationController
-
   # before_action :do_merchant, except: [:update, :destroy]
 
   def index
-    # @items = @merchant.items
+    @merchant = Merchant.find(params[:id])
   end
 
-
+  def show
+    # require "pry"
+    # binding.pry
+    @item = Item.find(params[:id])
+  end
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -1,5 +1,5 @@
 <h1> <%= @merchant.name %></h1>
 <h3> Items </h3>
 <% @merchant.items.each do |item| %>
-<p> <%= item.name %> </p>
+<p> <%= link_to  "#{item.name}", "/merchants/#{@merchant.id}/items/#{item.id}" %> </p>
 <% end %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -1,0 +1,4 @@
+<h1><%= @item.name %></h1>
+
+<h3>Description: <%= @item.description %></h3>
+<h3>Unit Price:  <%= @item.unit_price %></h3>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,8 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 
-  get 'merchants/:id/dashboard', to: 'merchants#show'
-  get 'merchants/:id/items', to: 'items#index'
-  get 'merchants/:id/invoices', to: 'invoices#index'
-
+  get "merchants/:id/dashboard", to: "merchants#show"
+  get "merchants/:id/items", to: "items#index"
+  get "merchants/:id/invoices", to: "invoices#index"
+  get "merchants/:id/items/:id", to: "items#show"
 end

--- a/spec/features/merchants/items/show_spec.rb
+++ b/spec/features/merchants/items/show_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+RSpec.describe "Merchant Items Show Page" do
+  before(:each) do
+    @merchant1 = Merchant.create!(name: "Klein, Rempel and Jones")
+    @merchant2 = Merchant.create!(name: "Williamson Group")
+
+    @item1 = @merchant1.items.create!(name: "Item Ea Voluptatum", description: "A thing that does things", unit_price: 7654)
+    @item2 = @merchant1.items.create!(name: "Item Quo Magnam", description: "A thing that does nothing", unit_price: 10099)
+    @item3 = @merchant1.items.create!(name: "Item Voluptatem Sint", description: "A thing that does everything", unit_price: 8790)
+    @item4 = @merchant2.items.create!(name: "Item Rerum Est", description: "A thing that barks", unit_price: 3455)
+    @item5 = @merchant2.items.create!(name: "Item Itaque Consequatur", description: "A thing that makes noise", unit_price: 7900)
+  end
+  describe "when I visit this page " do
+    it "has the items listed with of of its attribues" do
+      visit "/merchants/#{@merchant1.id}/items"
+
+      click_on "Item Quo Magnam"
+
+      expect(current_path).to eq("/merchants/#{@merchant1.id}/items/#{@item2.id}")
+      expect(page).to have_content(@item2.name)
+      expect(page).to have_content(@item.description)
+      expect(page).to have_content(@item2.unit_price)
+      expect(page).to_not have_content(@item4.name)
+    end
+  end
+end

--- a/spec/features/merchants/items/show_spec.rb
+++ b/spec/features/merchants/items/show_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "Merchant Items Show Page" do
 
       expect(current_path).to eq("/merchants/#{@merchant1.id}/items/#{@item2.id}")
       expect(page).to have_content(@item2.name)
-      expect(page).to have_content(@item.description)
+      expect(page).to have_content(@item2.description)
       expect(page).to have_content(@item2.unit_price)
       expect(page).to_not have_content(@item4.name)
     end


### PR DESCRIPTION
User story 34
Merchant Items Show Page

As a merchant,
When I click on the name of an item from the merchant items index page,
Then I am taken to that merchant's item's show page (/merchants/merchant_id/items/item_id)
And I see all of the item's attributes including:

- Name
- Description
- Current Selling Price

Things done: 
added tests for show page items listed with attributes
added route for items#show
added show to items_controller
added link to item's show page on item index view
added item name, description and unit price to item show page

files added: 
spec/features/merchants/items/show_spec.rb
app/views/ items/show_spec/rb
files affected:
apps/controllers/items_controller
apps/views/items/index.html.erb
config/routes.rb

