### PR TITLE
Aw admin dashboard 22 21

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -1,0 +1,2 @@
+class AdminController < ApplicationController
+end

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -1,2 +1,4 @@
 class AdminController < ApplicationController
+  def show
+  end
 end

--- a/app/views/admin/show.html.erb
+++ b/app/views/admin/show.html.erb
@@ -1,0 +1,1 @@
+<h1>Welcome to Admin Dashboard</h1>

--- a/app/views/admin/show.html.erb
+++ b/app/views/admin/show.html.erb
@@ -1,1 +1,3 @@
 <h1>Welcome to Admin Dashboard</h1>
+<%= link_to "Merchants Index", '/admin/merchants' %>
+<%= link_to "Invoices Index", '/admin/invoices' %>

--- a/spec/features/admin/show_spec.rb
+++ b/spec/features/admin/show_spec.rb
@@ -6,4 +6,11 @@ RSpec.describe "the admin dashboard" do
 
     expect(page).to have_content("Welcome to Admin Dashboard")
   end
+
+  it "shows links to access merchant and invoice index" do
+    visit "/admin"
+
+    expect(page).to have_link("Merchants Index")
+    expect(page).to have_link("Invoices Index")
+  end
 end

--- a/spec/features/admin/show_spec.rb
+++ b/spec/features/admin/show_spec.rb
@@ -1,0 +1,9 @@
+require "rails_helper"
+
+RSpec.describe "the admin dashboard" do
+  it "shows a header to the dashboard" do
+    visit "/admin"
+
+    expect(page).to have_content("Welcome to Admin Dashboard")
+  end
+end


### PR DESCRIPTION
Admin Dashboard

As an admin,
When I visit the admin dashboard (/admin)
Then I see a header indicating that I am on the admin dashboard

Admin Dashboard Links

As an admin,
When I visit the admin dashboard (/admin)
Then I see a link to the admin merchants index (/admin/merchants)
And I see a link to the admin invoices index (/admin/invoices)

things done: 
added admin show_page 
added links to merchant and invoice index
added tests for show page header 
added test for merchant and invoice index links 

files changed:
controllers/admin_controllers
views/admin/show
features/admin/show_page

New learnings: N/A