### PR TITLE
Aw admin dashboard 19 18

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -1,4 +1,5 @@
 class AdminController < ApplicationController
   def show
+    @invoices = Invoice.all
   end
 end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -5,4 +5,8 @@ class Invoice < ApplicationRecord
   has_many :transactions
 
   enum status: {"cancelled" => 0, "in progress" => 1, "completed" => 2}
+
+  def self.not_completed
+    where(invoices: {status: 1}).order(created_at: :asc)
+  end
 end

--- a/app/views/admin/show.html.erb
+++ b/app/views/admin/show.html.erb
@@ -1,3 +1,10 @@
 <h1>Welcome to Admin Dashboard</h1>
 <%= link_to "Merchants Index", '/admin/merchants' %>
 <%= link_to "Invoices Index", '/admin/invoices' %>
+
+<h2>Incomplete Invoices</h2>
+<div class="incompleted_invoices">
+  <% @invoices.not_completed.each do |invoice| %>
+    <p><%= link_to "Invoice: #{invoice.id}", "/admin/invoices/#{invoice.id}" %> Created On: <%= invoice.created_at.strftime("%A, %B %d, %Y") %></p>
+  <% end %>
+</div>

--- a/spec/features/admin/show_spec.rb
+++ b/spec/features/admin/show_spec.rb
@@ -13,4 +13,36 @@ RSpec.describe "the admin dashboard" do
     expect(page).to have_link("Merchants Index")
     expect(page).to have_link("Invoices Index")
   end
+
+  it "has a list of all incompleted invoices with their ID, which is a link to its show page" do
+    customer_1 = Customer.create!(first_name: "John", last_name: "Smith")
+
+    invoice_1 = customer_1.invoices.create!(status: "in progress")
+    invoice_2 = customer_1.invoices.create!(status: "in progress")
+    invoice_3 = customer_1.invoices.create!(status: "completed")
+    invoice_4 = customer_1.invoices.create!(status: "cancelled")
+
+    visit "/admin"
+
+    within(".incompleted_invoices") do
+      expect(page).to have_content(invoice_1.id)
+      expect(page).to have_content(invoice_2.id)
+      expect(page).to_not have_content(invoice_3.id)
+      expect(page).to_not have_content(invoice_4.id)
+      expect(page).to have_link("Invoice: #{invoice_2.id}")
+    end
+  end
+  it "list of incompleted invoices is ordered from least recent to most recent" do
+    customer_1 = Customer.create!(first_name: "Person 1", last_name: "Mcperson 1")
+
+    invoice_1 = customer_1.invoices.create!(status: "in progress", created_at: "2022-04-10")
+    invoice_2 = customer_1.invoices.create!(status: "in progress", created_at: "2022-04-09")
+    invoice_3 = customer_1.invoices.create!(status: "in progress", created_at: "2022-04-08")
+    visit "/admin"
+
+    within(".incompleted_invoices") do
+      expect(invoice_3.created_at.strftime("%A, %B %d, %Y")).to appear_before(invoice_2.created_at.strftime("%A, %B %d, %Y"))
+      expect(invoice_2.created_at.strftime("%A, %B %d, %Y")).to appear_before(invoice_1.created_at.strftime("%A, %B %d, %Y"))
+    end
+  end
 end

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -3,9 +3,9 @@ require "rails_helper"
 RSpec.describe Invoice, type: :model do
   describe "relationships" do
     it { should belong_to(:customer) }
-    it { should have_many(:invoice_items)}
-    it { should have_many(:items).through(:invoice_items)}
-    it { should have_many(:transactions)}
+    it { should have_many(:invoice_items) }
+    it { should have_many(:items).through(:invoice_items) }
+    it { should have_many(:transactions) }
   end
 
   describe "validations" do
@@ -13,7 +13,19 @@ RSpec.describe Invoice, type: :model do
   end
 
   describe "instance methods" do
-    
   end
 
+  describe "class methods" do
+    it "can return all invoices that are incomplete aka 'in progress'" do
+      customer_1 = Customer.create!(first_name: "Burt", last_name: "Bacharach")
+
+      invoice_1 = customer_1.invoices.create!(status: "in progress")
+      invoice_2 = customer_1.invoices.create!(status: "in progress")
+      invoice_3 = customer_1.invoices.create!(status: "cancelled")
+      invoice_4 = customer_1.invoices.create!(status: "completed")
+      invoice_5 = customer_1.invoices.create!(status: "completed")
+
+      expect(Invoice.not_completed).to eq([invoice_1, invoice_2])
+    end
+  end
 end


### PR DESCRIPTION
User Story 19
Admin Dashboard Incomplete Invoices

As an admin,
When I visit the admin dashboard
Then I see a section for "Incomplete Invoices"
In that section I see a list of the ids of all invoices
That have items that have not yet been shipped
And each invoice id links to that invoice's admin show page

User Story 18
As an admin,
When I visit the admin dashboard
In the section for "Incomplete Invoices",
Next to each invoice id I see the date that the invoice was created
And I see the date formatted like "Monday, July 18, 2019"
And I see that the list is ordered from oldest to newest

Things learned:  grouping and aggregating in ActiveRecord 

relevent code: 
where(invoices: {status: 1}).order(created_at: :asc)

files changed:
controllers/admin_controllers
models/invoice
views/admin/show.html
spec/features/admin/show_spec
spec/models/invoice