### PR TITLE
Sb rake refactor

### DIFF
--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -1,7 +1,7 @@
 class Customer < ApplicationRecord
-  has_many :invoices
-  has_many :transactions, through: :invoices 
+  has_many :invoices, dependent: :destroy
+  has_many :transactions, through: :invoices
   validates_presence_of :first_name, :last_name
 
- 
+
 end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -1,8 +1,8 @@
 class Invoice < ApplicationRecord
   belongs_to :customer
-  has_many :invoice_items
+  has_many :invoice_items, dependent: :destroy
   has_many :items, through: :invoice_items
-  has_many :transactions
+  has_many :transactions, dependent: :destroy
 
   enum status: {"cancelled" => 0, "in progress" => 1, "completed" => 2}
 

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,6 +1,6 @@
 class Item < ApplicationRecord
 
-	has_many :invoice_items
+	has_many :invoice_items, dependent: :destroy
 	belongs_to	:merchant
 	has_many :invoices, through: :invoice_items
 

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -1,10 +1,10 @@
 class Merchant < ApplicationRecord
-  has_many :items
+  has_many :items, dependent: :destroy
   has_many :invoice_items, through: :items
   has_many :invoices, through: :invoice_items
   has_many :customers, through: :invoices
   has_many :transactions, through: :invoices
-  
+
   validates_presence_of(:name)
 
   def items_ready_to_ship

--- a/lib/tasks/csv_load.rake
+++ b/lib/tasks/csv_load.rake
@@ -7,8 +7,7 @@ namespace :csv_load do
     CSV.foreach('./db/data/merchants.csv', headers: true) do |row|
       Merchant.create!(row.to_h)
     end
-    table = 'merchants'
-    ActiveRecord::Base.connection.reset_pk_sequence!(table)
+    ActiveRecord::Base.connection.reset_pk_sequence!("merchants")
   end
 
   task invoice_items: :environment do
@@ -16,10 +15,7 @@ namespace :csv_load do
     CSV.foreach('./db/data/invoice_items.csv', headers: true) do |row|
       InvoiceItem.create!(row.to_h)
     end
-
-    table = 'invoice_items'
-    auto_inc_val = 4015
-    ActiveRecord::Base.connection.execute("ALTER SEQUENCE #{table}_id_seq RESTART WITH #{auto_inc_val}")
+    ActiveRecord::Base.connection.reset_pk_sequence!("invoice_items")
   end
 
   task invoices: :environment do
@@ -27,10 +23,7 @@ namespace :csv_load do
     CSV.foreach('./db/data/invoices.csv', headers: true) do |row|
       Invoice.create!(row.to_h)
     end
-
-    table = 'invoices'
-    auto_inc_val = 901
-    ActiveRecord::Base.connection.execute("ALTER SEQUENCE #{table}_id_seq RESTART WITH #{auto_inc_val}")
+    ActiveRecord::Base.connection.reset_pk_sequence!("invoices")
   end
 
   task items: :environment do
@@ -38,10 +31,7 @@ namespace :csv_load do
     CSV.foreach('./db/data/items.csv', headers: true) do |row|
       Item.create!(row.to_h)
     end
-
-    table = 'items'
-    auto_inc_val = 2484
-    ActiveRecord::Base.connection.execute("ALTER SEQUENCE #{table}_id_seq RESTART WITH #{auto_inc_val}")
+    ActiveRecord::Base.connection.reset_pk_sequence!("items")
   end
 
   task transactions: :environment do
@@ -49,10 +39,7 @@ namespace :csv_load do
     CSV.foreach('./db/data/transactions.csv', headers: true) do |row|
       Transaction.create!(row.to_h)
     end
-
-    table = 'transactions'
-    auto_inc_val = 1045
-    ActiveRecord::Base.connection.execute("ALTER SEQUENCE #{table}_id_seq RESTART WITH #{auto_inc_val}")
+    ActiveRecord::Base.connection.reset_pk_sequence!("transactions")
   end
 
   task customers: :environment do
@@ -60,18 +47,13 @@ namespace :csv_load do
     CSV.foreach('./db/data/customers.csv', headers: true) do |row|
       Customer.create!(row.to_h)
     end
-
-    table = 'customers'
-    auto_inc_val = 1001
-    ActiveRecord::Base.connection.execute("ALTER SEQUENCE #{table}_id_seq RESTART WITH #{auto_inc_val}")
+    ActiveRecord::Base.connection.reset_pk_sequence!("customers")
   end
 
   task :all do
     tables = [:customers, :merchants, :invoices, :items, :invoice_items, :transactions]
     tables.each do |table|
       Rake::Task["csv_load:#{table}"].invoke
-      ActiveRecord::Base.connection.reset_pk_sequence!(table)
     end
-    require "pry"; binding.pry
   end
 end

--- a/lib/tasks/csv_load.rake
+++ b/lib/tasks/csv_load.rake
@@ -7,10 +7,8 @@ namespace :csv_load do
     CSV.foreach('./db/data/merchants.csv', headers: true) do |row|
       Merchant.create!(row.to_h)
     end
-
     table = 'merchants'
-    auto_inc_val = 101
-    ActiveRecord::Base.connection.execute("ALTER SEQUENCE #{table}_id_seq RESTART WITH #{auto_inc_val}")
+    ActiveRecord::Base.connection.reset_pk_sequence!(table)
   end
 
   task invoice_items: :environment do
@@ -67,11 +65,13 @@ namespace :csv_load do
     auto_inc_val = 1001
     ActiveRecord::Base.connection.execute("ALTER SEQUENCE #{table}_id_seq RESTART WITH #{auto_inc_val}")
   end
-  
+
   task :all do
     tables = [:customers, :merchants, :invoices, :items, :invoice_items, :transactions]
     tables.each do |table|
       Rake::Task["csv_load:#{table}"].invoke
+      ActiveRecord::Base.connection.reset_pk_sequence!(table)
     end
+    require "pry"; binding.pry
   end
 end


### PR DESCRIPTION
Reworked the rake file from what we learned with Kelsey

Added dependent: :destroy to all models with dependents
Did this so that the destroy_all in the rake files can be used, if you destroy all of a model class that has dependents it destroys all the classes that need the one being destroyed

Refactored the lines of code to reset the sequence of new primary keys. 

Was googling around to see if there is a way to send arguments to a rake task to slim it down even more, but it's not a necessary thing more out of my own curiosity and if I end up with some time I may try it again