### PR TITLE
Kg merchants group by status 13

### DIFF
--- a/app/controllers/admin/merchants_controller.rb
+++ b/app/controllers/admin/merchants_controller.rb
@@ -1,0 +1,27 @@
+class Admin::MerchantsController < ApplicationController
+
+  # def index
+  #   @invoices = Invoice.all
+  # end
+
+  # def show
+  #   @invoice = Invoice.find(params[:id])
+  # end
+
+  def edit
+    merchant = Merchant.find(params[:id])
+  end
+
+  def update
+    merchant = Merchant.find(params[:id])
+    merchant.update(merchant_params)
+    redirect_to 
+
+  end
+
+private
+  def merchant_params
+    params.require(:merchant).permit(:name)
+  end
+
+end

--- a/app/controllers/admin/merchants_controller.rb
+++ b/app/controllers/admin/merchants_controller.rb
@@ -9,19 +9,19 @@ class Admin::MerchantsController < ApplicationController
   end
 
   def edit
-    merchant = Merchant.find(params[:id])
+    @merchant = Merchant.find(params[:id])
   end
 
   def update
     merchant = Merchant.find(params[:id])
     merchant.update(merchant_params)
-    redirect_to 
-
+    redirect_to "/admin/merchants/#{merchant.id}"
+    flash[:alert] = "Merchant info successfully updated!"
   end
 
 private
   def merchant_params
-    params.require(:merchant).permit(:name)
+    params.permit(:name)
   end
 
 end

--- a/app/controllers/admin/merchants_controller.rb
+++ b/app/controllers/admin/merchants_controller.rb
@@ -4,6 +4,9 @@ class Admin::MerchantsController < ApplicationController
     @merchants = Merchant.all
   end
 
+  def show
+    @merchant = Merchant.find(params[:id])
+  end
 
   def edit
     merchant = Merchant.find(params[:id])

--- a/app/controllers/admin/merchants_controller.rb
+++ b/app/controllers/admin/merchants_controller.rb
@@ -1,12 +1,9 @@
 class Admin::MerchantsController < ApplicationController
 
-  # def index
-  #   @invoices = Invoice.all
-  # end
+  def index
+    @merchants = Merchant.all
+  end
 
-  # def show
-  #   @invoice = Invoice.find(params[:id])
-  # end
 
   def edit
     merchant = Merchant.find(params[:id])

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -3,5 +3,4 @@ class Customer < ApplicationRecord
   has_many :transactions, through: :invoices 
   validates_presence_of :first_name, :last_name
 
- 
 end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -7,6 +7,17 @@ class Merchant < ApplicationRecord
   
   validates_presence_of(:name)
 
+  def self.top_5_merchants
+     merchants_with_valid_invoices = self.joins(invoices: :transactions)
+                                           .where('transactions.result = 0')
+                                           .select('merchants.*').distinct
+    merchants_with_valid_invoices.joins(:invoice_items)
+                                 .select('merchants.*, sum(invoice_items.quantity * invoice_items.unit_price) as total_revenue')
+                                 .group(:id)
+                                 .order(total_revenue: :desc)
+                                 .limit(5)
+  end
+
   def items_ready_to_ship
     InvoiceItem.where(item: items).where.not(status: 2)
   end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -6,7 +6,7 @@ class Merchant < ApplicationRecord
   has_many :transactions, through: :invoices
   
   validates_presence_of(:name)
-
+  enum status: {"enabled" => 0, "disabled" => 1}
   def self.top_5_merchants
      merchants_with_valid_invoices = self.joins(invoices: :transactions)
                                            .where('transactions.result = 0')
@@ -16,6 +16,14 @@ class Merchant < ApplicationRecord
                                  .group(:id)
                                  .order(total_revenue: :desc)
                                  .limit(5)
+  end
+
+  def self.enabled_merchants
+    where(status: 0)
+  end
+
+  def self.disabled_merchants
+    where(status: 1)
   end
 
   def items_ready_to_ship

--- a/app/views/admin/merchants/edit.html.erb
+++ b/app/views/admin/merchants/edit.html.erb
@@ -1,5 +1,5 @@
 <div id=update_merchant>
-  <%= form_with model: @merchant, local: true do |form| %>
+  <%= form_with url: "/admin/merchants/#{@merchant.id}", method: :patch, local:true do |form| %>
     <%= form.label "Name:" %>
     <%= form.text_field :name, :value => @merchant.name %>
     <%= form.submit 'Submit' %>

--- a/app/views/admin/merchants/edit.html.erb
+++ b/app/views/admin/merchants/edit.html.erb
@@ -1,0 +1,7 @@
+<div id=update_merchant>
+  <%= form_with model: @merchant, local: true do |form| %>
+    <%= form.label "Name:" %>
+    <%= form.text_field :name, :value => @merchant.name %>
+    <%= form.submit 'Submit' %>
+  <% end %>
+</div>

--- a/app/views/admin/merchants/index.html.erb
+++ b/app/views/admin/merchants/index.html.erb
@@ -1,4 +1,12 @@
-<h1>All Merchants</h1>
+<h3>Top 5 Merchants:</h3>
+<% @merchants.top_5_merchants.each do |merchant|%>
+	<section id = "top_5-<%= merchant.id %>">
+		<p><%= merchant.name %> , 
+			Total Revenue: $<%= '%.02f' %  (merchant.total_revenue.to_f/100) %></p>
+	</section>
+<% end %>
+<br>
+<h3>All Merchants</h3>
 <% @merchants.each do |merchant|%>
 	<p><%= link_to "#{merchant.name}", "/admin/merchants/#{merchant.id}" %></p>
 <% end %>

--- a/app/views/admin/merchants/index.html.erb
+++ b/app/views/admin/merchants/index.html.erb
@@ -1,12 +1,32 @@
-<h3>Top 5 Merchants:</h3>
+<h2>Top 5 Merchants:</h2>
 <% @merchants.top_5_merchants.each do |merchant|%>
 	<section id = "top_5-<%= merchant.id %>">
 		<p><%= merchant.name %> , 
 			Total Revenue: $<%= '%.02f' %  (merchant.total_revenue.to_f/100) %></p>
 	</section>
 <% end %>
+
 <br>
-<h3>All Merchants</h3>
-<% @merchants.each do |merchant|%>
-	<p><%= link_to "#{merchant.name}", "/admin/merchants/#{merchant.id}" %></p>
-<% end %>
+<h2>All Merchants</h2>
+
+
+<h3> Enabled Merchants </h3>
+<section class="enabled">
+    <% @merchants.enabled_merchants.each do |merchant| %>
+      <div class="merchant-<%=merchant.id%>">
+          <p> <%= link_to  "#{merchant.name}", "/admin/merchants/#{merchant.id}" %> </p>
+          <p>Status: Enabled</p>
+      </div>
+      <% end %>
+</section>
+
+<h3> Disabled Merchants </h3>
+<section class="disabled">
+    <% @merchants.disabled_merchants.each do |merchant| %>
+      <div class="merchant-<%=merchant.id%>"
+          <p> <%= link_to  "#{merchant.name}", "/admin/merchants/#{merchant.id}" %> </p>
+          <p>Status: Disabled</p>
+      </div>
+      <% end %>
+</section>
+

--- a/app/views/admin/merchants/index.html.erb
+++ b/app/views/admin/merchants/index.html.erb
@@ -1,0 +1,4 @@
+<h1>All Merchants</h1>
+<% @merchants.each do |merchant|%>
+	<p><%= merchant.name %></p>
+<% end %>

--- a/app/views/admin/merchants/index.html.erb
+++ b/app/views/admin/merchants/index.html.erb
@@ -1,4 +1,4 @@
 <h1>All Merchants</h1>
 <% @merchants.each do |merchant|%>
-	<p><%= merchant.name %></p>
+	<p><%= link_to "#{merchant.name}", "/admin/merchants/#{merchant.id}" %></p>
 <% end %>

--- a/app/views/admin/merchants/show.html.erb
+++ b/app/views/admin/merchants/show.html.erb
@@ -1,0 +1,2 @@
+<h4>Merchant Info</h4>
+<p><%= @merchant.name %></p>

--- a/app/views/admin/merchants/show.html.erb
+++ b/app/views/admin/merchants/show.html.erb
@@ -1,2 +1,3 @@
 <h4>Merchant Info</h4>
 <p><%= @merchant.name %></p>
+<%= link_to 'Update Merchant', edit_admin_merchant_path %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,7 +17,7 @@ Rails.application.routes.draw do
   patch "merchants/:merchant_id/invoice_items/:invoice_item_id", to: "invoice_items#update"
 
   namespace :admin do
-    resources :merchants, only: [:index, :show, :new, :create, :update]
+    resources :merchants, only: [:index, :show, :new, :create, :edit, :update]
     resources :invoices, only: [:index, :show, :update]
   end
 end

--- a/db/migrate/20220418044154_add_status_to_merchants.rb
+++ b/db/migrate/20220418044154_add_status_to_merchants.rb
@@ -1,0 +1,5 @@
+class AddStatusToMerchants < ActiveRecord::Migration[5.2]
+  def change
+    add_column :merchants, :status, :integer, :default => "enabled"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_04_10_211119) do
+ActiveRecord::Schema.define(version: 2022_04_18_044154) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -57,6 +57,7 @@ ActiveRecord::Schema.define(version: 2022_04_10_211119) do
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "status", default: 0
   end
 
   create_table "transactions", force: :cascade do |t|

--- a/spec/factories/item.rb
+++ b/spec/factories/item.rb
@@ -3,6 +3,7 @@ FactoryBot.define do
     association :merchant
     name { Faker::Commerce.product_name}
     description { Faker::Commerce.material }
+    status {[0, 1].sample}
     unit_price { Faker::Number.within(range: 1..100_000)}
     id { Faker::Number.unique.within(range: 1..100_000)}
   end

--- a/spec/factories/merchant.rb
+++ b/spec/factories/merchant.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
   factory :merchant do
     name { Faker::Company.name }
+    status {[0, 1].sample}
     id { Faker::Number.unique.within(range: 1..100_000) }
   end
 end

--- a/spec/features/admin/merchants/edit_spec.rb
+++ b/spec/features/admin/merchants/edit_spec.rb
@@ -1,15 +1,16 @@
 require "rails_helper"
 
 RSpec.describe "the admin merchants edit page" do
-  it "edits an existing merchant" do
-    visit edit_admin_merchant_path
+  it "show page has a link leads to editing an existing merchant" do
+    merchant = FactoryBot.create_list(:merchant,1)[0]
+    visit "/admin/merchants/#{merchant.id}" 
 
-    fill_in 'Name', with: 'Something new'
+    click_link 'Update Merchant'
+    expect(current_path).to eq("/admin/merchants/#{merchant.id}/edit")
+
+    fill_in 'name', with: 'Something new'
     click_button 'Submit'
     
-    expect(page).to have_content("Welcome to Admin Dashboard")
-  end
-
-
+    expect(page).to have_content("Something new")
   end
 end

--- a/spec/features/admin/merchants/edit_spec.rb
+++ b/spec/features/admin/merchants/edit_spec.rb
@@ -1,8 +1,8 @@
 require "rails_helper"
 
-RSpec.describe "the admin merchants page" do
+RSpec.describe "the admin merchants edit page" do
   it "edits an existing merchant" do
-    visit edit_admin_merchant
+    visit edit_admin_merchant_path
 
     fill_in 'Name', with: 'Something new'
     click_button 'Submit'

--- a/spec/features/admin/merchants/edit_spec.rb
+++ b/spec/features/admin/merchants/edit_spec.rb
@@ -1,0 +1,15 @@
+require "rails_helper"
+
+RSpec.describe "the admin merchants page" do
+  it "edits an existing merchant" do
+    visit edit_admin_merchant
+
+    fill_in 'Name', with: 'Something new'
+    click_button 'Submit'
+    
+    expect(page).to have_content("Welcome to Admin Dashboard")
+  end
+
+
+  end
+end

--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -18,4 +18,67 @@ RSpec.describe "the admin merchants indexpage" do
 
     expect(current_path).to eq("/admin/merchants/#{merchant.id}")
   end
+
+
+  it 'lists the top five merchants and their total revenue' do 
+    merchant1 = FactoryBot.create_list(:merchant, 1, name: 'merchant1')[0]
+    merchant2 = FactoryBot.create_list(:merchant, 1, name: 'merchant2')[0]
+    merchant3 = FactoryBot.create_list(:merchant, 1, name: 'merchant3')[0]
+    merchant4 = FactoryBot.create_list(:merchant, 1, name: 'merchant4')[0]
+    merchant5 = FactoryBot.create_list(:merchant, 1, name: 'merchant5')[0]
+    merchant6 = FactoryBot.create_list(:merchant, 1, name: 'merchant6')[0]
+
+    item1 = FactoryBot.create_list(:item, 1, merchant: merchant1)[0]
+    item2 = FactoryBot.create_list(:item, 1, merchant: merchant2)[0]
+    item3 = FactoryBot.create_list(:item, 1, merchant: merchant3)[0]
+    item4 = FactoryBot.create_list(:item, 1, merchant: merchant4)[0]
+    item5 = FactoryBot.create_list(:item, 1, merchant: merchant5)[0]
+    item6 = FactoryBot.create_list(:item, 1, merchant: merchant6)[0]
+        
+    invoice1 = FactoryBot.create_list(:invoice, 1)[0]
+    invoice2 = FactoryBot.create_list(:invoice, 1)[0]
+    invoice3 = FactoryBot.create_list(:invoice, 1)[0]
+    invoice4 = FactoryBot.create_list(:invoice, 1)[0]
+    invoice5 = FactoryBot.create_list(:invoice, 1)[0]
+    invoice6 = FactoryBot.create_list(:invoice, 1)[0]
+        
+    invoice_item1 = FactoryBot.create_list(:invoice_item, 1, invoice: invoice1, item: item1, quantity: 10, unit_price: 1000)[0]
+    invoice_item2 = FactoryBot.create_list(:invoice_item, 1, invoice: invoice2, item: item2, quantity: 9, unit_price: 1000)[0]
+    invoice_item3 = FactoryBot.create_list(:invoice_item, 1, invoice: invoice3, item: item3, quantity: 8, unit_price: 1000)[0]
+    invoice_item4 = FactoryBot.create_list(:invoice_item, 1, invoice: invoice4, item: item4, quantity: 7, unit_price: 1000)[0]
+    invoice_item5 = FactoryBot.create_list(:invoice_item, 1, invoice: invoice5, item: item5, quantity: 5, unit_price: 1000)[0]
+    invoice_item6 = FactoryBot.create_list(:invoice_item, 1, invoice: invoice6, item: item6, quantity: 9, unit_price: 1000)[0]
+
+    transaction1_0 = FactoryBot.create_list(:transaction, 1, invoice: invoice1, result:0)
+    transaction1_1 = FactoryBot.create_list(:transaction, 1, invoice: invoice1, result:1)
+    transaction2_1 = FactoryBot.create_list(:transaction, 1, invoice: invoice2, result:1)
+    transaction3_0 = FactoryBot.create_list(:transaction, 1, invoice: invoice3, result:0)
+    transaction4_0 = FactoryBot.create_list(:transaction, 1, invoice: invoice4, result:0)
+    transaction5_1 = FactoryBot.create_list(:transaction, 1, invoice: invoice5, result:1)
+    transaction5_0 = FactoryBot.create_list(:transaction, 1, invoice: invoice5, result:0)
+    transaction6_0 = FactoryBot.create_list(:transaction, 1, invoice: invoice6, result:0)
+
+    visit admin_merchants_path
+
+    within("#top_5-#{merchant1.id}") do 
+      expect(page).to have_content(merchant1.name)
+      expect(page).to have_content(100.00)
+    end
+    within("#top_5-#{merchant6.id}") do 
+      expect(page).to have_content(merchant6.name)
+      expect(page).to have_content(90.00)
+    end
+    within("#top_5-#{merchant3.id}") do 
+      expect(page).to have_content(merchant3.name)
+      expect(page).to have_content(80.00)
+    end
+    within("#top_5-#{merchant4.id}") do 
+      expect(page).to have_content(merchant4.name)
+      expect(page).to have_content(70.00)
+    end
+    within("#top_5-#{merchant5.id}") do 
+      expect(page).to have_content(merchant5.name)
+      expect(page).to have_content(50.00)
+    end
+  end
 end

--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -1,0 +1,12 @@
+require "rails_helper"
+
+RSpec.describe "the admin merchants indexpage" do
+  it "lists all merchants name in the system" do
+    FactoryBot.create_list(:merchant, 5)
+
+    visit admin_merchants_path
+    Merchant.all.each do |merchant|
+      expect(page).to have_content(merchant.name)
+    end
+  end
+end

--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -1,12 +1,21 @@
 require "rails_helper"
 
 RSpec.describe "the admin merchants indexpage" do
-  it "lists all merchants name in the system" do
+  it 'lists all merchants name in the system' do
     FactoryBot.create_list(:merchant, 5)
 
     visit admin_merchants_path
     Merchant.all.each do |merchant|
       expect(page).to have_content(merchant.name)
     end
+  end
+
+  it 'has a name link to admin merchant show page' do 
+    merchant = FactoryBot.create_list(:merchant,1)[0]
+    visit admin_merchants_path
+
+    click_link merchant.name
+
+    expect(current_path).to eq("/admin/merchants/#{merchant.id}")
   end
 end

--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -19,6 +19,36 @@ RSpec.describe "the admin merchants indexpage" do
     expect(current_path).to eq("/admin/merchants/#{merchant.id}")
   end
 
+  it 'lists merchants grouped by status' do 
+    merchant1 = FactoryBot.create_list(:merchant, 1, status: 0)[0]
+    merchant2 = FactoryBot.create_list(:merchant, 1, status: 0)[0]
+    merchant3 = FactoryBot.create_list(:merchant, 1, status: 0)[0]
+    merchant4 = FactoryBot.create_list(:merchant, 1, status: 1)[0]
+    merchant5 = FactoryBot.create_list(:merchant, 1, status: 1)[0]
+    merchant6 = FactoryBot.create_list(:merchant, 1, status: 1)[0]
+
+    visit admin_merchants_path
+
+    within(".enabled") do
+      expect(page).to have_content(merchant1.name)
+      expect(page).to have_content(merchant2.name)
+      expect(page).to have_content(merchant3.name)
+      expect(page).to_not have_content(merchant4.name)
+      expect(page).to_not have_content(merchant5.name)
+      expect(page).to_not have_content(merchant6.name)
+    end
+
+    within(".disabled") do
+      expect(page).to_not have_content(merchant1.name)
+      expect(page).to_not have_content(merchant2.name)
+      expect(page).to_not have_content(merchant3.name)
+      expect(page).to have_content(merchant4.name)
+      expect(page).to have_content(merchant5.name)
+      expect(page).to have_content(merchant6.name)
+    end
+
+
+  end 
 
   it 'lists the top five merchants and their total revenue' do 
     merchant1 = FactoryBot.create_list(:merchant, 1, name: 'merchant1')[0]

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -97,5 +97,50 @@ RSpec.describe Merchant, type: :model do
           expect(merchant1.top_5_customers).to eq([cust5, cust3, cust1, cust6, cust2])
        end
      end
-  end
+   end
+    
+   describe 'class methods' do 
+      describe '#top_5_merchants' do 
+        it 'returns the top five merchanst with largest total revenue' do 
+          merchant1 = FactoryBot.create_list(:merchant, 1, name: 'merchant1')[0]
+          merchant2 = FactoryBot.create_list(:merchant, 1, name: 'merchant2')[0]
+          merchant3 = FactoryBot.create_list(:merchant, 1, name: 'merchant3')[0]
+          merchant4 = FactoryBot.create_list(:merchant, 1, name: 'merchant4')[0]
+          merchant5 = FactoryBot.create_list(:merchant, 1, name: 'merchant5')[0]
+          merchant6 = FactoryBot.create_list(:merchant, 1, name: 'merchant6')[0]
+
+          item1 = FactoryBot.create_list(:item, 1, merchant: merchant1)[0]
+          item2 = FactoryBot.create_list(:item, 1, merchant: merchant2)[0]
+          item3 = FactoryBot.create_list(:item, 1, merchant: merchant3)[0]
+          item4 = FactoryBot.create_list(:item, 1, merchant: merchant4)[0]
+          item5 = FactoryBot.create_list(:item, 1, merchant: merchant5)[0]
+          item6 = FactoryBot.create_list(:item, 1, merchant: merchant6)[0]
+        
+          invoice1 = FactoryBot.create_list(:invoice, 1)[0]
+          invoice2 = FactoryBot.create_list(:invoice, 1)[0]
+          invoice3 = FactoryBot.create_list(:invoice, 1)[0]
+          invoice4 = FactoryBot.create_list(:invoice, 1)[0]
+          invoice5 = FactoryBot.create_list(:invoice, 1)[0]
+          invoice6 = FactoryBot.create_list(:invoice, 1)[0]
+        
+          invoice_item1 = FactoryBot.create_list(:invoice_item, 1, invoice: invoice1, item: item1, quantity: 10, unit_price: 10)[0]
+          invoice_item2 = FactoryBot.create_list(:invoice_item, 1, invoice: invoice2, item: item2, quantity: 9, unit_price: 10)[0]
+          invoice_item3 = FactoryBot.create_list(:invoice_item, 1, invoice: invoice3, item: item3, quantity: 8, unit_price: 10)[0]
+          invoice_item4 = FactoryBot.create_list(:invoice_item, 1, invoice: invoice4, item: item4, quantity: 7, unit_price: 10)[0]
+          invoice_item5 = FactoryBot.create_list(:invoice_item, 1, invoice: invoice5, item: item5, quantity: 5, unit_price: 10)[0]
+          invoice_item6 = FactoryBot.create_list(:invoice_item, 1, invoice: invoice6, item: item6, quantity: 9, unit_price: 10)[0]
+
+          transaction1_0 = FactoryBot.create_list(:transaction, 1, invoice: invoice1, result:0)
+          transaction1_1 = FactoryBot.create_list(:transaction, 1, invoice: invoice1, result:1)
+          transaction2_1 = FactoryBot.create_list(:transaction, 1, invoice: invoice2, result:1)
+          transaction3_0 = FactoryBot.create_list(:transaction, 1, invoice: invoice3, result:0)
+          transaction4_0 = FactoryBot.create_list(:transaction, 1, invoice: invoice4, result:0)
+          transaction5_1 = FactoryBot.create_list(:transaction, 1, invoice: invoice5, result:1)
+          transaction5_0 = FactoryBot.create_list(:transaction, 1, invoice: invoice5, result:0)
+          transaction6_0 = FactoryBot.create_list(:transaction, 1, invoice: invoice6, result:0)
+
+          expect(Merchant.top_5_merchants).to eq([merchant1, merchant6, merchant3, merchant4, merchant5])
+        end
+      end
+    end
 end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe Merchant, type: :model do
 
   describe "validations" do
     it { should validate_presence_of(:name) }
+    it { should define_enum_for(:status).with([:enabled, :disabled])}
   end
 
 
@@ -141,6 +142,20 @@ RSpec.describe Merchant, type: :model do
 
           expect(Merchant.top_5_merchants).to eq([merchant1, merchant6, merchant3, merchant4, merchant5])
         end
+      end
+
+      describe '#enabled_merchants, #disabled_merchants' do 
+        it 'lists enabled and disabled merchants' do 
+          merchant1 = FactoryBot.create_list(:merchant, 1, status: 0)[0]
+          merchant2 = FactoryBot.create_list(:merchant, 1, status: 0)[0]
+          merchant3 = FactoryBot.create_list(:merchant, 1, status: 0)[0]
+          merchant4 = FactoryBot.create_list(:merchant, 1, status: 1)[0]
+          merchant5 = FactoryBot.create_list(:merchant, 1, status: 1)[0]
+          merchant6 = FactoryBot.create_list(:merchant, 1, status: 1)[0]
+
+          expect(Merchant.enabled_merchants).to eq([merchant1, merchant2, merchant3])
+          expect(Merchant.disabled_merchants).to eq([merchant4, merchant5, merchant6])
+        end 
       end
     end
 end


### PR DESCRIPTION
user story
As an admin,
When I visit the admin merchants index
Then I see two sections, one for "Enabled Merchants" and one for "Disabled Merchants"
And I see that each Merchant is listed in the appropriate section

Notes:
added new migration to add status column to merchants. 
must db:migrate to udpate db.