### PR TITLE
Aw mii 5 most pop items 29

### DIFF
--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -4,7 +4,7 @@ class Merchant < ApplicationRecord
   has_many :invoices, through: :invoice_items
   has_many :customers, through: :invoices
   has_many :transactions, through: :invoices
-  
+
   validates_presence_of(:name)
 
   def items_ready_to_ship
@@ -20,11 +20,33 @@ class Merchant < ApplicationRecord
   end
 
   def top_5_customers
-     customers.joins(:transactions)
-             .where('transactions.result = 0 AND invoices.status = 2')
-             .select("customers.*, count(transactions.*) as transaction_count")
-             .group(:id)
-             .order(transaction_count: :desc)
-             .limit(5)
+    customers.joins(:transactions)
+      .where("transactions.result = 0 AND invoices.status = 2")
+      .select("customers.*, count(transactions.*) as transaction_count")
+      .group(:id)
+      .order(transaction_count: :desc)
+      .limit(5)
   end
+
+  def popular_items
+    items.joins(invoice_items: {invoice: :transactions})
+      .where(transactions: {result: 0})
+      .select("items.*, SUM( invoice_items.unit_price * invoice_items.quantity)  AS totalrevenue")
+      .group(:id)
+      .order(totalrevenue: :desc)
+      .limit(5)
+  end
+
+  # def popular_items(item_count = 5)
+  #   if item_count > items.count
+  #     item_count = items.count
+  #   end
+  #
+  #   items.joins(:transactions)
+  #     .select("items.*")
+  #     .merge(Transaction.successful)
+  #     .merge(InvoiceItem.grouped_total_revenue)
+  #     .order(revenue: :desc)
+  #     .limit(item_count)
+  # end
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -7,7 +7,7 @@
 <section class="enabled">
     <% @merchant.enabled_items.each do |item| %>
       <div class="item-<%=item.id%>">
-          <p> <%= link_to  "#{item.name}", "/merchants/#{@merchant.id}/items/#{item.id}" %> 
+          <p> <%= link_to  "#{item.name}", "/merchants/#{@merchant.id}/items/#{item.id}" %>
             <%= button_to "Disable", "/merchants/#{@merchant.id}/items", params: {disable: item.id}, method: :patch %>
           </p>
       </div>
@@ -18,10 +18,19 @@
 <section class="disabled">
     <% @merchant.disabled_items.each do |item| %>
       <div class="item-<%=item.id%>"
-          <p> <%= link_to  "#{item.name}", "/merchants/#{@merchant.id}/items/#{item.id}" %> 
+          <p> <%= link_to  "#{item.name}", "/merchants/#{@merchant.id}/items/#{item.id}" %>
             <%= button_to "Enable", "/merchants/#{@merchant.id}/items", params: {enable: item.id}, method: :patch  %>
           </p>
       </div>
       <% end %>
 </section>
 
+<div class="top_items">
+  <ol>
+    <h3>Top 5 Items by Revenue</h3>
+    <% @merchant.popular_items.each do |item| %>
+      <%= link_to "#{item.name}", "/merchants/#{@merchant.id}/items/#{item.id}" %>
+      <%= item.totalrevenue %>
+    <% end %>
+  </ol>
+</div>

--- a/spec/features/merchants/items/index_spec.rb
+++ b/spec/features/merchants/items/index_spec.rb
@@ -21,7 +21,6 @@ RSpec.describe "merchants items index page", type: :feature do
     expect(page).not_to have_content(@item5.name)
   end
 
-
   it "has a link to create a new item" do
     visit "/merchants/#{@merchant1.id}/items"
 
@@ -30,11 +29,11 @@ RSpec.describe "merchants items index page", type: :feature do
     expect(current_path).to eq("/merchants/#{@merchant1.id}/items/new")
   end
 
-  it 'has the ability to enable or disable an item' do
+  it "has the ability to enable or disable an item" do
     visit "/merchants/#{@merchant1.id}/items"
 
     expect(@item1.status).to eq("enabled")
-    
+
     within ".item-#{@item1.id}" do
       click_on "Disable"
     end
@@ -59,7 +58,7 @@ RSpec.describe "merchants items index page", type: :feature do
     end
   end
 
-  it 'groups items by disabled or enabled items' do
+  it "groups items by disabled or enabled items" do
     visit "/merchants/#{@merchant1.id}/items"
 
     expect(page).to have_content("Enabled Items")
@@ -73,5 +72,73 @@ RSpec.describe "merchants items index page", type: :feature do
     within ".disabled" do
       expect(page).to have_content(@item3.name)
     end
+  end
+
+  it "section with top 5 popular_items" do
+    merchant_1 = Merchant.create!(name: "Stuff and Things ")
+    item_1 = FactoryBot.create_list(:item, 1, merchant_id: merchant_1.id)[0]
+    item_2 = FactoryBot.create_list(:item, 2, merchant_id: merchant_1.id)[1]
+    item_3 = FactoryBot.create_list(:item, 3, merchant_id: merchant_1.id)[2]
+    item_4 = FactoryBot.create_list(:item, 4, merchant_id: merchant_1.id)[3]
+    item_5 = FactoryBot.create_list(:item, 5, merchant_id: merchant_1.id)[4]
+    item_6 = FactoryBot.create_list(:item, 6, merchant_id: merchant_1.id)[5]
+    item_7 = FactoryBot.create_list(:item, 7, merchant_id: merchant_1.id)[6]
+
+    FactoryBot.create_list(:customer, 7)
+    cust1 = Customer.all[0]
+    cust2 = Customer.all[1]
+    cust3 = Customer.all[2]
+    cust4 = Customer.all[3]
+    cust5 = Customer.all[4]
+    cust6 = Customer.all[5]
+    cust7 = Customer.all[6]
+
+    invoice1 = FactoryBot.create_list(:invoice, 1, customer_id: cust1.id, status: 2)[0]
+    invoice2 = FactoryBot.create_list(:invoice, 2, customer_id: cust2.id, status: 2)[1]
+    invoice3 = FactoryBot.create_list(:invoice, 3, customer_id: cust3.id, status: 2)[2]
+    invoice4 = FactoryBot.create_list(:invoice, 4, customer_id: cust4.id, status: 2)[3]
+    invoice5 = FactoryBot.create_list(:invoice, 5, customer_id: cust5.id, status: 0)[4]
+    invoice6 = FactoryBot.create_list(:invoice, 6, customer_id: cust6.id, status: 2)[5]
+    invoice7 = FactoryBot.create_list(:invoice, 7, customer_id: cust7.id, status: 2)[6]
+
+    FactoryBot.create_list(:invoice_item, 1, item_id: item_1.id, invoice_id: invoice1.id)
+    FactoryBot.create_list(:invoice_item, 2, item_id: item_2.id, invoice_id: invoice2.id)
+    FactoryBot.create_list(:invoice_item, 3, item_id: item_3.id, invoice_id: invoice3.id)
+    FactoryBot.create_list(:invoice_item, 4, item_id: item_4.id, invoice_id: invoice4.id)
+    FactoryBot.create_list(:invoice_item, 5, item_id: item_5.id, invoice_id: invoice5.id)
+    FactoryBot.create_list(:invoice_item, 6, item_id: item_6.id, invoice_id: invoice6.id)
+    FactoryBot.create_list(:invoice_item, 7, item_id: item_7.id, invoice_id: invoice7.id)
+
+    FactoryBot.create_list(:transaction, 1, invoice_id: invoice1.id, result: 1)
+    FactoryBot.create_list(:transaction, 2, invoice_id: invoice2.id, result: 0)
+    FactoryBot.create_list(:transaction, 3, invoice_id: invoice3.id, result: 0)
+    FactoryBot.create_list(:transaction, 4, invoice_id: invoice4.id, result: 0)
+    FactoryBot.create_list(:transaction, 5, invoice_id: invoice5.id, result: 1)
+    FactoryBot.create_list(:transaction, 6, invoice_id: invoice6.id, result: 0)
+    FactoryBot.create_list(:transaction, 7, invoice_id: invoice7.id, result: 0)
+    visit "/merchants/#{merchant_1.id}/items"
+    expect(page).to have_content("Top 5 Items by Revenue")
+
+    within ".top_items" do
+      expect(page).to have_link(item_7.name)
+      expect(page).to have_link(item_6.name)
+      expect(page).to have_link(item_4.name)
+      expect(page).to have_link(item_3.name)
+      expect(page).to have_link(item_2.name)
+
+      expect(item_7.name).to appear_before(item_6.name)
+      expect(item_6.name).to appear_before(item_4.name)
+      expect(item_4.name).to appear_before(item_2.name)
+
+      # expect(page).to have_content("19777219")
+      # expect(page).to have_content("9899016")
+      # expect(page).to have_content("3737512")
+      # expect(page).to have_content("1897324")
+      # expect(page).to have_content("1244265")
+    end
+    within ".top_items" do
+      click_link(item_2.name)
+    end
+    expect(current_path).to eq("/merchants/#{merchant_1.id}/items/#{item_2.id}")
   end
 end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -3,20 +3,19 @@ require "rails_helper"
 RSpec.describe Merchant, type: :model do
   describe "relationships" do
     it { should have_many :items }
-    it { should have_many(:invoice_items).through(:items)}
-    it { should have_many(:invoices).through(:invoice_items)}
-    it { should have_many(:customers).through(:invoices)}
-    it { should have_many(:transactions).through(:invoices)}
+    it { should have_many(:invoice_items).through(:items) }
+    it { should have_many(:invoices).through(:invoice_items) }
+    it { should have_many(:customers).through(:invoices) }
+    it { should have_many(:transactions).through(:invoices) }
   end
 
   describe "validations" do
     it { should validate_presence_of(:name) }
   end
 
-
-  describe 'instance methods' do
-    describe '.items_ready_to_ship' do
-      it 'returns invoice_items of a merchant with status other than shipped' do
+  describe "instance methods" do
+    describe ".items_ready_to_ship" do
+      it "returns invoice_items of a merchant with status other than shipped" do
         @merchant1 = Merchant.create!(name: "Schroeder-Jerde")
         @item1 = @merchant1.items.create!(name: "Item Qui Esse", description: "Nihil autem sit odio inventore deleniti. Est lauda...", unit_price: 75107)
         @item2 = @merchant1.items.create!(name: "Item Autem Minima", description: "Cumque consequuntur ad. Fuga tenetur illo molestia...", unit_price: 67076)
@@ -24,78 +23,125 @@ RSpec.describe Merchant, type: :model do
         @customer1 = Customer.create!(first_name: "Joey", last_name: "Ondricka")
         @invoice1 = Invoice.create!(customer_id: @customer1.id, status: "cancelled")
         @invoice2 = Invoice.create!(customer_id: @customer1.id, status: "in progress")
-        @invoice_item1 = InvoiceItem.create!(item_id: @item1.id, invoice_id: @invoice1.id, quantity: 1, unit_price: 75100, status: "shipped",)
-        @invoice_item2 = InvoiceItem.create!(item_id: @item2.id, invoice_id: @invoice2.id, quantity: 3, unit_price: 200000, status: "packaged",)
-        @invoice_item3 = InvoiceItem.create!(item_id: @item3.id, invoice_id: @invoice2.id, quantity: 1, unit_price: 32301, status: "pending",)
-
+        @invoice_item1 = InvoiceItem.create!(item_id: @item1.id, invoice_id: @invoice1.id, quantity: 1, unit_price: 75100, status: "shipped")
+        @invoice_item2 = InvoiceItem.create!(item_id: @item2.id, invoice_id: @invoice2.id, quantity: 3, unit_price: 200000, status: "packaged")
+        @invoice_item3 = InvoiceItem.create!(item_id: @item3.id, invoice_id: @invoice2.id, quantity: 1, unit_price: 32301, status: "pending")
 
         expect(@merchant1.items_ready_to_ship).to eq([@invoice_item2, @invoice_item3])
       end
     end
-    describe 'enabled/disabled items' do
-      before (:each) do
+    describe "enabled/disabled items" do
+      before(:each) do
         @merchant1 = Merchant.create!(name: "Klein, Rempel and Jones")
         @merchant2 = Merchant.create!(name: "Williamson Group")
 
-        @item1 = @merchant1.items.create!(name: "Item Ea Voluptatum",   description: "A thing that does things", unit_price: 7654)
+        @item1 = @merchant1.items.create!(name: "Item Ea Voluptatum", description: "A thing that does things", unit_price: 7654)
         @item2 = @merchant1.items.create!(name: "Item Quo Magnam", description: "A thing that does nothing", unit_price: 10099)
         @item3 = @merchant1.items.create!(name: "Item Voluptatem Sint", description: "A thing that does everything", unit_price: 8790, status: "disabled")
         @item4 = @merchant2.items.create!(name: "Item Rerum Est", description: "A thing that barks", unit_price: 3455)
         @item5 = @merchant2.items.create!(name: "Item Itaque Consequatur", description: "A thing that makes noise", unit_price: 7900)
       end
 
-      it '#enabled_items' do
+      it "#enabled_items" do
         expect(@merchant1.enabled_items).to eq([@item1, @item2])
         expect(@merchant2.enabled_items).to eq([@item4, @item5])
       end
 
-      it '#disabled_items' do
+      it "#disabled_items" do
         expect(@merchant1.disabled_items).to eq([@item3])
         expect(@merchant2.disabled_items).to eq([])
       end
     end
 
-      describe '.top_5_customers' do 
-        it 'returns top-5 customers with most successful transactions' do 
-          merchant1 = Merchant.create!(name: "Klein, Rempel and Jones")
-          item1 = FactoryBot.create_list(:item, 1, merchant_id: merchant1.id)[0]
-          FactoryBot.create_list(:customer, 7) 
-          cust1 = Customer.all[0]
-          cust2 = Customer.all[1]
-          cust3 = Customer.all[2]
-          cust4 = Customer.all[3]
-          cust5 = Customer.all[4]
-          cust6 = Customer.all[5]
-          cust7 = Customer.all[6]
-          
-          invoice1 = FactoryBot.create_list(:invoice, 1, customer_id: cust5.id, status: 2)[0]
-          invoice2 = FactoryBot.create_list(:invoice, 1, customer_id: cust3.id, status: 2)[0]
-          invoice3 = FactoryBot.create_list(:invoice, 1, customer_id: cust1.id, status: 2)[0]
-          invoice4 = FactoryBot.create_list(:invoice, 1, customer_id: cust6.id, status: 2)[0]
-          invoice5 = FactoryBot.create_list(:invoice, 1, customer_id: cust7.id, status: 0)[0]
-          invoice6 = FactoryBot.create_list(:invoice, 1, customer_id: cust2.id, status: 2)[0]
-          invoice7 = FactoryBot.create_list(:invoice, 1, customer_id: cust4.id, status: 2)[0]
+    describe ".top_5_customers" do
+      it "returns top-5 customers with most successful transactions" do
+        merchant1 = Merchant.create!(name: "Klein, Rempel and Jones")
+        item1 = FactoryBot.create_list(:item, 1, merchant_id: merchant1.id)[0]
+        FactoryBot.create_list(:customer, 7)
+        cust1 = Customer.all[0]
+        cust2 = Customer.all[1]
+        cust3 = Customer.all[2]
+        cust4 = Customer.all[3]
+        cust5 = Customer.all[4]
+        cust6 = Customer.all[5]
+        cust7 = Customer.all[6]
 
-          FactoryBot.create_list(:invoice_item, 1, item_id: item1.id, invoice_id: invoice1.id)
-          FactoryBot.create_list(:invoice_item, 1, item_id: item1.id, invoice_id: invoice2.id)
-          FactoryBot.create_list(:invoice_item, 1, item_id: item1.id, invoice_id: invoice3.id)
-          FactoryBot.create_list(:invoice_item, 1, item_id: item1.id, invoice_id: invoice4.id)
-          FactoryBot.create_list(:invoice_item, 1, item_id: item1.id, invoice_id: invoice5.id)
-          FactoryBot.create_list(:invoice_item, 1, item_id: item1.id, invoice_id: invoice6.id)
-          FactoryBot.create_list(:invoice_item, 1, item_id: item1.id, invoice_id: invoice7.id)
+        invoice1 = FactoryBot.create_list(:invoice, 1, customer_id: cust5.id, status: 2)[0]
+        invoice2 = FactoryBot.create_list(:invoice, 1, customer_id: cust3.id, status: 2)[0]
+        invoice3 = FactoryBot.create_list(:invoice, 1, customer_id: cust1.id, status: 2)[0]
+        invoice4 = FactoryBot.create_list(:invoice, 1, customer_id: cust6.id, status: 2)[0]
+        invoice5 = FactoryBot.create_list(:invoice, 1, customer_id: cust7.id, status: 0)[0]
+        invoice6 = FactoryBot.create_list(:invoice, 1, customer_id: cust2.id, status: 2)[0]
+        invoice7 = FactoryBot.create_list(:invoice, 1, customer_id: cust4.id, status: 2)[0]
 
+        FactoryBot.create_list(:invoice_item, 1, item_id: item1.id, invoice_id: invoice1.id)
+        FactoryBot.create_list(:invoice_item, 1, item_id: item1.id, invoice_id: invoice2.id)
+        FactoryBot.create_list(:invoice_item, 1, item_id: item1.id, invoice_id: invoice3.id)
+        FactoryBot.create_list(:invoice_item, 1, item_id: item1.id, invoice_id: invoice4.id)
+        FactoryBot.create_list(:invoice_item, 1, item_id: item1.id, invoice_id: invoice5.id)
+        FactoryBot.create_list(:invoice_item, 1, item_id: item1.id, invoice_id: invoice6.id)
+        FactoryBot.create_list(:invoice_item, 1, item_id: item1.id, invoice_id: invoice7.id)
 
-          FactoryBot.create_list(:transaction, 10, invoice_id: invoice1.id, result: 0) 
-          FactoryBot.create_list(:transaction, 8, invoice_id: invoice2.id, result: 0) 
-          FactoryBot.create_list(:transaction, 7, invoice_id: invoice3.id, result: 0) 
-          FactoryBot.create_list(:transaction, 6, invoice_id: invoice4.id, result: 0) 
-          FactoryBot.create_list(:transaction, 4, invoice_id: invoice5.id, result: 0) 
-          FactoryBot.create_list(:transaction, 2, invoice_id: invoice6.id, result: 0) 
-          FactoryBot.create_list(:transaction, 1, invoice_id: invoice7.id, result: 0) 
-          
+        FactoryBot.create_list(:transaction, 10, invoice_id: invoice1.id, result: 0)
+        FactoryBot.create_list(:transaction, 8, invoice_id: invoice2.id, result: 0)
+        FactoryBot.create_list(:transaction, 7, invoice_id: invoice3.id, result: 0)
+        FactoryBot.create_list(:transaction, 6, invoice_id: invoice4.id, result: 0)
+        FactoryBot.create_list(:transaction, 4, invoice_id: invoice5.id, result: 0)
+        FactoryBot.create_list(:transaction, 2, invoice_id: invoice6.id, result: 0)
+        FactoryBot.create_list(:transaction, 1, invoice_id: invoice7.id, result: 0)
 
-          expect(merchant1.top_5_customers).to eq([cust5, cust3, cust1, cust6, cust2])
-       end
-     end
+        expect(merchant1.top_5_customers).to eq([cust5, cust3, cust1, cust6, cust2])
+      end
+    end
+
+    describe "popular_items" do
+      it "returns a list of items ordered by potential_revenue" do
+        merchant_1 = Merchant.create!(name: "Stuff and Things ")
+        item_1 = FactoryBot.create_list(:item, 1, merchant_id: merchant_1.id)[0]
+        item_2 = FactoryBot.create_list(:item, 2, merchant_id: merchant_1.id)[1]
+        item_3 = FactoryBot.create_list(:item, 3, merchant_id: merchant_1.id)[2]
+        item_4 = FactoryBot.create_list(:item, 4, merchant_id: merchant_1.id)[3]
+        item_5 = FactoryBot.create_list(:item, 5, merchant_id: merchant_1.id)[4]
+        item_6 = FactoryBot.create_list(:item, 6, merchant_id: merchant_1.id)[5]
+        item_7 = FactoryBot.create_list(:item, 7, merchant_id: merchant_1.id)[6]
+
+        FactoryBot.create_list(:customer, 7)
+        cust1 = Customer.all[0]
+        cust2 = Customer.all[1]
+        cust3 = Customer.all[2]
+        cust4 = Customer.all[3]
+        cust5 = Customer.all[4]
+        cust6 = Customer.all[5]
+        cust7 = Customer.all[6]
+
+        invoice1 = FactoryBot.create_list(:invoice, 1, customer_id: cust1.id, status: 2)[0]
+        invoice2 = FactoryBot.create_list(:invoice, 2, customer_id: cust2.id, status: 2)[1]
+        invoice3 = FactoryBot.create_list(:invoice, 3, customer_id: cust3.id, status: 2)[2]
+        invoice4 = FactoryBot.create_list(:invoice, 4, customer_id: cust4.id, status: 2)[3]
+        invoice5 = FactoryBot.create_list(:invoice, 5, customer_id: cust5.id, status: 0)[4]
+        invoice6 = FactoryBot.create_list(:invoice, 6, customer_id: cust6.id, status: 2)[5]
+        invoice7 = FactoryBot.create_list(:invoice, 7, customer_id: cust7.id, status: 2)[6]
+
+        FactoryBot.create_list(:invoice_item, 1, item_id: item_1.id, invoice_id: invoice1.id)
+        FactoryBot.create_list(:invoice_item, 2, item_id: item_2.id, invoice_id: invoice2.id)
+        FactoryBot.create_list(:invoice_item, 3, item_id: item_3.id, invoice_id: invoice3.id)
+        FactoryBot.create_list(:invoice_item, 4, item_id: item_4.id, invoice_id: invoice4.id)
+        FactoryBot.create_list(:invoice_item, 5, item_id: item_5.id, invoice_id: invoice5.id)
+        FactoryBot.create_list(:invoice_item, 6, item_id: item_6.id, invoice_id: invoice6.id)
+        FactoryBot.create_list(:invoice_item, 7, item_id: item_7.id, invoice_id: invoice7.id)
+
+        FactoryBot.create_list(:transaction, 1, invoice_id: invoice1.id, result: 1)
+        FactoryBot.create_list(:transaction, 2, invoice_id: invoice2.id, result: 0)
+        FactoryBot.create_list(:transaction, 3, invoice_id: invoice3.id, result: 0)
+        FactoryBot.create_list(:transaction, 4, invoice_id: invoice4.id, result: 0)
+        FactoryBot.create_list(:transaction, 5, invoice_id: invoice5.id, result: 1)
+        FactoryBot.create_list(:transaction, 6, invoice_id: invoice6.id, result: 0)
+        FactoryBot.create_list(:transaction, 7, invoice_id: invoice7.id, result: 0)
+
+        expected = [item_7, item_6, item_4, item_3, item_2]
+
+        expect(merchant_1.popular_items).to eq(expected)
+      end
+    end
   end
 end


### PR DESCRIPTION
User Story 29
Merchant Items Index: 5 most popular items
As a merchant
When I visit my items index page
Then I see the names of the top 5 most popular items ranked by total revenue generated
And I see that each item name links to my merchant item show page for that item
And I see the total revenue generated next to each item name

Notes on Revenue Calculation:

Only invoices with at least one successful transaction should count towards revenue
Revenue for an invoice should be calculated as the sum of the revenue of all invoice items
Revenue for an invoice item should be calculated as the invoice item unit price multiplied by the quantity (do not use the item unit price)

Files changed:
app/models/merchant
app/views/items/index
spec/features/merchants/items/index
spec/models/merchant 

Added code to view for top 5 items by revenue 
added popular_items method to merchant model 