### PR TITLE
Kg api username

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,8 @@ gem "jbuilder", "~> 2.5"
 # Reduces boot times through caching; required in config/boot.rb
 
 gem "bootsnap", ">= 1.1.0", require: false
+gem 'httparty'
+gem 'json'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,11 +86,16 @@ GEM
     ffi (1.15.5-x86-mingw32)
     globalid (1.0.0)
       activesupport (>= 5.0)
+    httparty (0.20.0)
+      mime-types (~> 3.0)
+      multi_xml (>= 0.5.2)
     i18n (1.10.0)
       concurrent-ruby (~> 1.0)
     jbuilder (2.11.5)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
+    json (2.6.1)
+    json (2.6.1-java)
     launchy (2.5.0)
       addressable (~> 2.7)
     listen (3.1.5)
@@ -105,11 +110,15 @@ GEM
     marcel (1.0.2)
     matrix (0.4.2)
     method_source (1.0.0)
+    mime-types (3.4.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2022.0105)
     mini_mime (1.1.2)
     mini_portile2 (2.8.0)
     minitest (5.15.0)
     msgpack (1.5.1)
     msgpack (1.5.1-java)
+    multi_xml (0.6.0)
     nio4r (2.5.8)
     nio4r (2.5.8-java)
     nokogiri (1.13.3)
@@ -290,7 +299,9 @@ DEPENDENCIES
   coffee-rails (~> 4.2)
   factory_bot_rails
   faker
+  httparty
   jbuilder (~> 2.5)
+  json
   launchy
   listen (>= 3.0.5, < 3.2)
   orderly

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,8 @@
 class ApplicationController < ActionController::Base
+	before_action :repo_info, only: [:index, :show, :edit, :new]
+	
+	def repo_info
+		@contributors = GithubSearch.new.output
+	end
+
 end

--- a/app/facades/github_search.rb
+++ b/app/facades/github_search.rb
@@ -1,0 +1,20 @@
+require_relative '../services/github_service.rb'
+require_relative '../poros/contributor.rb'
+
+
+class GithubSearch
+	def output
+		json_info = GithubService.new.contributors
+		json_info.class != Hash ? contributor_information : json_info[:message]
+	end
+
+	def contributor_information
+		service.contributors.map do |data|
+			Contributor.new(data)
+		end
+	end
+
+	def service
+		GithubService.new
+	end
+end

--- a/app/poros/contributor.rb
+++ b/app/poros/contributor.rb
@@ -1,0 +1,9 @@
+class Contributor
+	attr_reader :user_name, :contributions
+
+	def initialize(data)
+		@user_name = data[:login]
+		@contributions = data[:contributions]
+	end
+
+end

--- a/app/services/github_service.rb
+++ b/app/services/github_service.rb
@@ -1,0 +1,16 @@
+require 'json'
+require 'httparty'
+
+class GithubService
+
+	def contributors
+		get_url("https://api.github.com/repos/sueboyd922/little-esty-shop/contributors")
+	end
+
+
+	def get_url(url)
+		response = HTTParty.get(url)
+		JSON.parse(response.body, symbolize_names: true)
+	end
+
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,5 +16,7 @@
     <% end %>
   </div>
     <%= yield %>
+
+    <%= render partial: '/partials/github_api' %>
   </body>
 </html>

--- a/app/views/partials/_github_api.html.erb
+++ b/app/views/partials/_github_api.html.erb
@@ -1,0 +1,14 @@
+
+<br><br><br><br><br>
+<section id = "github_info">
+<h3> About This Repository:</h3>
+<% if @repo_info.class == String %>
+      <h4>Unable to show Github Repo Details:</h4>
+      <p><%= @repo_info %></p>
+<% else %>
+  <h4>Usernames:</h4>
+   <% @contributors.map do |contributor| %>
+      <p><%= contributor.user_name %></p>
+   <%end %>
+<% end %>
+</section>

--- a/app/views/partials/_github_api.html.erb
+++ b/app/views/partials/_github_api.html.erb
@@ -2,9 +2,9 @@
 <br><br><br><br><br>
 <section id = "github_info">
 <h3> About This Repository:</h3>
-<% if @repo_info.class == String %>
+<% if @contributors.class == String %>
       <h4>Unable to show Github Repo Details:</h4>
-      <p><%= @repo_info %></p>
+      <p><%= @contributors %></p>
 <% else %>
   <h4>Usernames:</h4>
    <% @contributors.map do |contributor| %>

--- a/spec/facades/github_search_spec.rb
+++ b/spec/facades/github_search_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe GithubSearch do 
+	describe '.contributor_information' do 
+		it 'create contributor poros' do 
+			contributors = GithubSearch.new.contributor_information
+			expect(contributors.first).to be_a Contributor 
+		end
+	end
+end

--- a/spec/features/gh_info_spec.rb
+++ b/spec/features/gh_info_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe 'all index, show, edit, new pages' do 
+	it 'shows the team members usernames' do 
+		merchant = FactoryBot.create_list(:merchant,1)[0]
+		invoice = FactoryBot.create_list(:invoice, 1)[0]
+		item = FactoryBot.create_list(:item, 1, merchant: merchant)[0]
+		urls = ['/admin/merchants', '/admin/invoices', 
+				"/merchants/#{merchant.id}/dashboard", "/merchants/#{merchant.id}/items", 
+				"/merchants/#{merchant.id}/items/#{item.id}",
+				"/admin/merchants/#{merchant.id}", "/admin/invoices/#{invoice.id}"]
+
+		urls.each do |url|
+			visit url 
+			
+			within("#github_info") do 
+			expect(page).to have_content('sueboyd922')
+				expect(page).to have_content('kg-byte')
+				expect(page).to have_content('AliciaWatt')
+				expect(page).to have_content('CoryBethune')
+			end
+		end 
+	end
+end

--- a/spec/poros/contributor_spec.rb
+++ b/spec/poros/contributor_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+
+RSpec.describe Contributor do 
+	it 'exists and has user_name and contributions' do 
+		data = {login: 'kg-byte', contributions: 50}
+		contributor = Contributor.new(data)
+		expect(contributor).to be_a Contributor
+		expect(contributor.user_name).to eq'kg-byte'
+		expect(contributor.contributions).to eq 50
+	end
+
+
+end

--- a/spec/services/github_service_spec.rb
+++ b/spec/services/github_service_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe GithubService do 
+	describe '.get(url) and contributors' do 
+		it 'gets and parses url into a hash' do 
+			contributors_url = GithubService.new.get_url('https://api.github.com/repos/sueboyd922/little-esty-shop/contributors')
+			expect(contributors_url).to be_an Array 
+			expect(contributors_url.first[:login].nil?).to be false
+		end
+	end
+end


### PR DESCRIPTION
user story:
As a visitor or an admin user
When I visit any page on the site
I see the Github usernames of myself and my teammates somewhere on the site
The most up to date usernames are always displayed

Created facades/services/poros folder 
Consumed GH api-show usernames or error messages
Generated @contributors variable in application_controller
Made partial to handle GH info display in view/layout file (shows on every page)
